### PR TITLE
Include Environment in ASG Name

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -28,12 +28,16 @@ resource "aws_launch_configuration" "main" {
 
 resource "aws_autoscaling_group" "main" {
   count                = var.deployed ? 1 : 0
-  name                 = "asg-${var.project_id}-${var.deployed_app}-${var.deployment}"
+  name                 = "asg-${var.project_id}-${var.env}-${var.deployed_app}-${var.deployment}"
   launch_configuration = aws_launch_configuration.main[count.index].name
   min_size             = var.asg_min_size
   max_size             = var.asg_max_size
   target_group_arns    = var.target_group_arns
   vpc_zone_identifier  = var.subnet_ids
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
   tags = [
     {


### PR DESCRIPTION
Include the name of the environment in the ASG name to prevent errors
from occurring when trying to launch the same ASG in the same region,
but in different environments.

Signed-off-by: Jason Rogena <jason@rogena.me>